### PR TITLE
Add support for bitcode iOS SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The MobilePay SDK enables your app to receive payments through the MobilePay app
 |Platform|Version|
 |:--------|:---|
 |Android| 1.8.1|
-|iOS| 1.8.1|
+|iOS| 1.8.2|
 |WP| 1.8.0|
 
 ## Support


### PR DESCRIPTION
This is a request for you to enabled bitcode for the iOS SDK. I realise that this way of requesting it is a little odd but I thought it was worth a shot!

> Bitcode is an intermediate representation of a compiled program. Apps you upload to iTunes Connect that contain bitcode will be compiled and linked on the App Store. Including bitcode will allow Apple to re-optimize your app binary in the future without the need to submit a new version of your app to the store.
> 
> Note: For iOS apps, bitcode is the default, but optional. If you provide bitcode, all apps and frameworks in the app bundle need to include bitcode. For watchOS apps, bitcode is required

Apps using your framework must currently disable bitcode since MobilePay-AppSwitch-SDK has it disabled. Apple will most likely require bitcode in the future so enabling it is the right choice going forward.